### PR TITLE
bsp: ti: add bsp for am64xx-sk

### DIFF
--- a/bsp/ti/am64xx-sk-standard.scc
+++ b/bsp/ti/am64xx-sk-standard.scc
@@ -1,0 +1,7 @@
+define KMACHINE am64xx-sk
+define KARCH aarch64
+define KTYPE standard
+
+include ktypes/standard/standard.scc
+
+include ti-common.scc

--- a/bsp/ti/ti-common.scc
+++ b/bsp/ti/ti-common.scc
@@ -1,0 +1,12 @@
+# TI uses a defconfig_builder.sh script to provide most of the base settings
+# Only include the generic feature fragments to enable LmP support
+
+# Various RF/Wireless technologies
+include features/bluetooth/bluetooth.scc
+include features/bluetooth/bluetooth-usb.scc
+include features/bluetooth/bluetooth-uart.scc
+include features/ieee802154/ieee802154.scc
+include features/mac802154/mac802154.scc
+include features/hostapd/hostapd.scc
+
+include cfg/usb-mass-storage.scc


### PR DESCRIPTION
NOTE: The majority of the settings for am64xx-sk come from
TI's defconfig builder script used during OE recipe.

These are only the LmP feature additions.

Signed-off-by: Michael Scott <mike@foundries.io>