### PR TITLE
sun8i: Added missing orange-pi-r1-standard.scc

### DIFF
--- a/bsp/sun8i/orange-pi-r1-standard.scc
+++ b/bsp/sun8i/orange-pi-r1-standard.scc
@@ -1,0 +1,7 @@
+define KMACHINE orange-pi-r1
+define KARCH arm
+define KTYPE standard
+
+include ktypes/standard/standard.scc
+
+include orange-pi-r1.scc


### PR DESCRIPTION
Forgot to add this file to link everything together

Signed-off-by: Eric Bode <eric.bode@foundries.io>