### PR TITLE
Linux v5.10.y: support kirkstone for stm32mp1*

### DIFF
--- a/bsp/stm32/stm32mp1-disco.scc
+++ b/bsp/stm32/stm32mp1-disco.scc
@@ -46,4 +46,7 @@ include features/tee/tee.scc
 
 include cfg/usb-mass-storage.scc
 
+# Exclude x86/ACPI features
+include cfg/non-x86.cfg
+
 kconf hardware stm32mp1-disco.cfg

--- a/bsp/stm32/stm32mp1-eval.scc
+++ b/bsp/stm32/stm32mp1-eval.scc
@@ -46,4 +46,7 @@ include features/tee/tee.scc
 
 include cfg/usb-mass-storage.scc
 
+# Exclude x86/ACPI features
+include cfg/non-x86.cfg
+
 kconf hardware stm32mp1-eval.cfg

--- a/bsp/stm32/stm32mp15-disco-standard.scc
+++ b/bsp/stm32/stm32mp15-disco-standard.scc
@@ -1,0 +1,7 @@
+define KMACHINE stm32mp15-disco
+define KARCH arm
+define KTYPE standard
+
+include ktypes/standard/standard.scc
+
+include stm32mp1-disco.scc

--- a/bsp/stm32/stm32mp15-eval-standard.scc
+++ b/bsp/stm32/stm32mp15-eval-standard.scc
@@ -1,0 +1,7 @@
+define KMACHINE stm32mp15-eval
+define KARCH arm
+define KTYPE standard
+
+include ktypes/standard/standard.scc
+
+include stm32mp1-eval.scc


### PR DESCRIPTION
Add supporting the `kirkstone` release of `meta-st-stm32mp` layer.
