### PR TITLE
bsp: ti: Add standard for am62xx-evm

### DIFF
--- a/bsp/ti/am62xx-evm-standard.scc
+++ b/bsp/ti/am62xx-evm-standard.scc
@@ -1,0 +1,7 @@
+define KMACHINE am62xx-evm
+define KARCH aarch64
+define KTYPE standard
+
+include ktypes/standard/standard.scc
+
+include ti-common.scc


### PR DESCRIPTION
Signed-off-by: Tim Anderson <tim.anderson@foundries.io>