### PR TITLE
bsp: imx8mmevk: add preempt-rt definition

### DIFF
--- a/bsp/imx/imx8mmevk-preempt-rt.scc
+++ b/bsp/imx/imx8mmevk-preempt-rt.scc
@@ -1,0 +1,9 @@
+define KMACHINE imx8mmevk
+define KARCH aarch64
+define KTYPE preempt-rt
+
+include ktypes/standard/standard.scc
+
+include imx8mmevk.scc
+
+include ktypes/preempt-rt/preempt-rt.scc


### PR DESCRIPTION
Based on standard + preempt-rt fragment.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>