### PR TITLE
bsp: imx: apalis-imx6 enable DRM and HDMI

### DIFF
--- a/bsp/imx/apalis-imx6.cfg
+++ b/bsp/imx/apalis-imx6.cfg
@@ -99,19 +99,9 @@ CONFIG_HW_RANDOM_OPTEE=y
 CONFIG_MTD=y
 CONFIG_MTD_RAW_NAND=y
 CONFIG_IIO=y
+CONFIG_DRM_MXSFB=y
 # CONFIG_CRYPTO_DEV_FSL_CAAM is not set
 # CONFIG_CRYPTO_DEV_FSL_CAAM_JR is not set
-# Broken DRM
-# CONFIG_DRM_DW_HDMI is not set
-# CONFIG_DRM_DW_HDMI_CEC is not set
-# CONFIG_DRM_DW_HDMI_AHB_AUDIO is not set
-# CONFIG_DRM_IMX is not set
-# CONFIG_DRM_IMX_PARALLEL_DISPLAY is not set
-# CONFIG_DRM_IMX_TVE is not set
-# CONFIG_DRM_IMX_LDB is not set
-# CONFIG_DRM_IMX_HDMI is not set
-# CONFIG_DRM_ETNAVIV is not set
-# CONFIG_DRM_ETNAVIV_THERMAL is not set
 
 ## Disable options from other fragments that are not used by this BSP
 # CONFIG_SERIAL_8250_PNP is not set


### PR DESCRIPTION
Enable a set of drivers to have HDMI interface working.

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>