### PR TITLE
[linux-v6.1.y] 6.1 for arm32

### DIFF
--- a/bsp/imx/imx6ulevk.cfg
+++ b/bsp/imx/imx6ulevk.cfg
@@ -94,3 +94,6 @@ CONFIG_MAILBOX=y
 CONFIG_CRYPTO_USER_API_HASH=m
 CONFIG_CRYPTO_USER_API_SKCIPHER=m
 CONFIG_CRYPTO_USER_API_AEAD=m
+
+# Disable options from fragments included in imx6ulevk.scc
+# CONFIG_ISA_DMA_API is not set

--- a/bsp/imx/imx6ullevk.cfg
+++ b/bsp/imx/imx6ullevk.cfg
@@ -92,3 +92,6 @@ CONFIG_MAILBOX=y
 CONFIG_CRYPTO_USER_API_HASH=m
 CONFIG_CRYPTO_USER_API_SKCIPHER=m
 CONFIG_CRYPTO_USER_API_AEAD=m
+
+# Disable options from fragments included in imx6ullevk.scc
+# CONFIG_ISA_DMA_API is not set


### PR DESCRIPTION
The option CONFIG_ISA_DMA_API is incompatible with mach-imx anymore. Disable it.