### PR TITLE
bsp: imx6ulevk: fix preempt-rt

### DIFF
--- a/bsp/imx/imx6ulevk-preempt-rt.scc
+++ b/bsp/imx/imx6ulevk-preempt-rt.scc
@@ -1,6 +1,6 @@
 define KMACHINE imx6ulevk
 define KARCH arm
-define KTYPE standard
+define KTYPE preempt-rt
 
 include ktypes/standard/standard.scc
 


### PR DESCRIPTION
For RT kernel, the ktype should be preempt-rt. Fix it.